### PR TITLE
Add "communication protocol" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Dependency Status](https://david-dm.org/bencevans/tomahawk-network.js.png)](https://david-dm.org/bencevans/tomahawk-network.js)
 
 
-An implementation of [Tomahawk's](http://tomahawk-player.org) in JavaScript intended for Node.js, hopefully also supporting Google Chrome making use of it's chrome.socket API.
+An implementation of [Tomahawk's](http://tomahawk-player.org) communication protocol in JavaScript intended for Node.js, hopefully also supporting Google Chrome making use of it's chrome.socket API.
 
 ## API
 


### PR DESCRIPTION
I think you do not want this repo to be a full tomahawk clone, the name is more suggesting that it is just the communication.
